### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-build --java_language_version=17
-test --java_language_version=17
+build --java_language_version=21 --java_runtime_version=remotejdk_21
+test --java_language_version=21 --java_runtime_version=remotejdk_21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "17"
+          java-version: "21"
       - name: Mount bazel cache
         uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ IDE support is provided for [IntelliJ](https://www.jetbrains.com/idea/)
 
 1. `Import Bazel Project`
 2. Select repository root as Bazel workspace
-3. Select `Import project view file` and choose [project/bazel/java/java.bazelproject](./project/bazel/java/java.bazelproject)
-4. For `Project data directory` choose [project/bazel/java](./project/bazel/java)
+3. Select `Import project view file` and choose [project/intellij/java/java.bazelproject](./project/intellij/java/java.bazelproject)
+4. For `Project data directory` choose [project/intellij/java](./project/intellij/java)
 5. For `Project name` choose something like `monorepo-java`
 4. `Create`
 
@@ -40,7 +40,7 @@ IDE support is provided for [IntelliJ](https://www.jetbrains.com/idea/)
 
 1. `Import Bazel Project`
 2. Select repository root as Bazel workspace
-3. Select `Import project view file` and choose [project/bazel/python/python.bazelproject](./project/bazel/python/python.bazelproject)
-4. For `Project data directory` choose [project/bazel/python](./project/bazel/python)
+3. Select `Import project view file` and choose [project/intellij/python/python.bazelproject](./project/intellij/python/python.bazelproject)
+4. For `Project data directory` choose [project/intellij/python](./project/intellij/python)
 5. For `Project name` choose something like `monorepo-python`
 4. `Create`

--- a/project/intellij/java/java.bazelproject
+++ b/project/intellij/java/java.bazelproject
@@ -2,7 +2,7 @@
 
 workspace_type: java
 
-java_language_level: 17
+java_language_level: 21
 
 directories:
   # Add the directories you want added as source here


### PR DESCRIPTION
Local runtime version [Azul Zulu OpenJDK 21](https://www.azul.com/downloads/?version=java-21-lts&os=macos&architecture=x86-64-bit&package=jdk#zulu)

```
travels$ java -version
openjdk version "21.0.1" 2023-10-17 LTS
OpenJDK Runtime Environment Zulu21.30+15-CA (build 21.0.1+12-LTS)
OpenJDK 64-Bit Server VM Zulu21.30+15-CA (build 21.0.1+12-LTS, mixed mode, sharing)
```